### PR TITLE
Bugfix: Filename string ends at first zero byte

### DIFF
--- a/rsce/stuct.go
+++ b/rsce/stuct.go
@@ -7,8 +7,8 @@
  */
 
 // Package rsce aka Rockchip resources image.
-//It's a binary file which contains device tree blob and additional resources
-//(like vendor splash screen) and appears as boot.img-second on unpacking.
+// It's a binary file which contains device tree blob and additional resources
+// (like vendor splash screen) and appears as boot.img-second on unpacking.
 package rsce
 
 import (
@@ -49,11 +49,13 @@ type fileEntry struct {
 	FileSize      uint32
 }
 
-func removeZeroByte(src []byte) []byte {
+func endAtFirstZeroByte(src []byte) []byte {
 	var strBuf []byte
 	for _, v := range src {
 		if v != 0 {
 			strBuf = append(strBuf, v)
+		} else {
+			break
 		}
 	}
 	return strBuf

--- a/rsce/tool.go
+++ b/rsce/tool.go
@@ -10,11 +10,12 @@ package rsce
 
 import (
 	"encoding/binary"
-	"github.com/evsio0n/log"
 	"io/ioutil"
 	"math"
 	"os"
 	"path"
+
+	"github.com/evsio0n/log"
 )
 
 func UnPackRSCE(filepath string) {
@@ -53,7 +54,7 @@ func UnPackRSCE(filepath string) {
 		//Parse file name
 		//File name is 256 bytes and remove null bytes
 		strWithZeroByte := fileEntryBuffer[i*512+4 : i*512+260]
-		fileName := string(removeZeroByte(strWithZeroByte))
+		fileName := string(endAtFirstZeroByte(strWithZeroByte))
 
 		log.Info("Found File, name:", fileName)
 		//Parse file offset


### PR DESCRIPTION
While trying to unpack [resource.img.zip](https://github.com/Evsio0n/rsce-go/files/9936938/resource.img.zip), I noticed that not all tools generating the resource images files are cleaning up their buffers before writing the filename, and hence one needs to stop parsing filenames after the first zero byte.


